### PR TITLE
ci: run ci on arm64

### DIFF
--- a/.github/actions/rust-sccache/action.yml
+++ b/.github/actions/rust-sccache/action.yml
@@ -40,7 +40,11 @@ runs:
       shell: bash
     - name: Installing sccache
       run: |
-        asset_name='sccache-${{ inputs.version }}-x86_64-unknown-linux-musl'
+        asset_arch='x86_64'
+        if [[ '${{ runner.arch }}' == 'ARM64' ]]; then
+          asset_arch='aarch64'
+        fi
+        asset_name="sccache-${{ inputs.version }}-${asset_arch}-unknown-linux-musl"
         gh release download --repo 'mozilla/sccache' --dir '.' --pattern "$asset_name.tar.gz" '${{ inputs.version }}'
         tar -zxf "$asset_name.tar.gz"
         cp "$asset_name/sccache" '/usr/local/bin/sccache'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,7 @@ jobs:
     steps:
     - name: Machine setup (to be moved to the AMI)
       run: |
+        sudo yum group install "Development Tools"
         # Open up /usr/local/bin
         sudo chmod -R 777 /usr/local/bin
         # Add /usr/local/bin to PATH

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,9 +95,9 @@ jobs:
         command: generate-lockfile
     - name: Installing Cargo llvm-cov
       if: ${{ matrix.covname }}
-      uses: taiki-e/install-action@bc0a06a003a8225fe3e896c9ed3a4c3cc2e8416a
+      uses: taiki-e/install-action@47e0a4c507c49a64304ce95e89e9839ca14faef2 # v1.4.2
       with:
-        tool: cargo-llvm-cov@0.4.5
+        tool: cargo-llvm-cov@0.4.8
     - name: Setting up cache
       uses: ./.github/actions/rust-sccache
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,7 @@ jobs:
     - name: Machine setup (to be moved to the AMI)
       run: |
         # Install gh
+        mkdir -p /usr/share/keyrings/
         curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
         echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
         sudo apt update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,8 @@ jobs:
     steps:
     - name: Machine setup (to be moved to the AMI)
       run: |
+        # Open up /usr/local/bin
+        sudo chmod -R 777 /usr/local/bin
         # Install gh
         wget https://github.com/cli/cli/releases/download/v2.12.1/gh_2.12.1_linux_arm64.rpm
         sudo rpm -i gh_2.12.1_linux_arm64.rpm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,11 +67,7 @@ jobs:
     - name: Machine setup (to be moved to the AMI)
       run: |
         # Install gh
-        mkdir -p /usr/share/keyrings/
-        curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
-        echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-        sudo apt update
-        sudo apt install gh
+        sudo dnf install gh
       shell: bash
     - name: Checking out fvm
       uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
     - name: Machine setup (to be moved to the AMI)
       run: |
         # Install gh
-        sudo dnf install gh
+        yum install gh
       shell: bash
     - name: Checking out fvm
       uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,16 @@ jobs:
         version: v0.2.15
         # change this to invalidate sccache for this job
         shared-key: v1
+    - run: |
+        which sccache
+        echo ''
+        ls /home/ec2-user/.rustup/
+        echo ''
+        ls /home/ec2-user/.rustup/toolchains/
+        echo ''
+        ls /home/ec2-user/.rustup/toolchains/nightly-2022-05-09-aarch64-unknown-linux-gnu/
+        echo ''
+        ls /home/ec2-user/.rustup/toolchains/nightly-2022-05-09-aarch64-unknown-linux-gnu/bin/
     - name: Running ${{ matrix.command }}
       uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,8 @@ jobs:
     - name: Machine setup (to be moved to the AMI)
       run: |
         sudo yum group install -y "Development Tools"
-        sudo yum install -y cmake
+        sudo yum install -y epel-release cmake3
+        sudo ln -s /usr/bin/cmake3 /usr/bin/cmake
         # Open up /usr/local/bin
         sudo chmod -R 777 /usr/local/bin
         # Add /usr/local/bin to PATH

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   rustfmt:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, arm64, linux-arm64-default]
     steps:
     - name: Checking out fvm
       uses: actions/checkout@v2
@@ -27,7 +27,7 @@ jobs:
         command: fmt
         args: -- --check
   cargo:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, arm64, linux-arm64-default]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,8 @@ jobs:
       run: |
         # Open up /usr/local/bin
         sudo chmod -R 777 /usr/local/bin
+        # Add /usr/local/bin to PATH
+        echo '/usr/local/bin' >> $GITHUB_PATH
         # Install gh
         wget https://github.com/cli/cli/releases/download/v2.12.1/gh_2.12.1_linux_arm64.rpm
         sudo rpm -i gh_2.12.1_linux_arm64.rpm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
     - name: Machine setup (to be moved to the AMI)
       run: |
         # Install gh
-        yum install gh
+        sudo yum install gh
       shell: bash
     - name: Checking out fvm
       uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,14 @@ jobs:
       CARGO_INCREMENTAL: 0
     name: ${{ matrix.name }}
     steps:
+    - name: Machine setup (to be moved to the AMI)
+      run: |
+        # Install gh
+        curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+        echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+        sudo apt update
+        sudo apt install gh
+      shell: bash
     - name: Checking out fvm
       uses: actions/checkout@v2
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,8 @@ jobs:
     - name: Machine setup (to be moved to the AMI)
       run: |
         # Install gh
-        sudo yum install gh
+        wget https://github.com/cli/cli/releases/download/v2.12.1/gh_2.12.1_linux_arm64.rpm
+        sudo rpm -i gh_2.12.1_linux_arm64.rpm
       shell: bash
     - name: Checking out fvm
       uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
     steps:
     - name: Machine setup (to be moved to the AMI)
       run: |
-        sudo yum group install "Development Tools"
+        sudo yum group install -y "Development Tools"
         # Open up /usr/local/bin
         sudo chmod -R 777 /usr/local/bin
         # Add /usr/local/bin to PATH

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,7 @@ jobs:
     - name: Machine setup (to be moved to the AMI)
       run: |
         sudo yum group install -y "Development Tools"
+        sudo yum install -y cmake
         # Open up /usr/local/bin
         sudo chmod -R 777 /usr/local/bin
         # Add /usr/local/bin to PATH

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,9 +95,10 @@ jobs:
         command: generate-lockfile
     - name: Installing Cargo llvm-cov
       if: ${{ matrix.covname }}
-      uses: taiki-e/install-action@47e0a4c507c49a64304ce95e89e9839ca14faef2 # v1.4.2
+      uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
       with:
-        tool: cargo-llvm-cov@0.4.8
+        command: install
+        args: cargo-llvm-cov
     - name: Setting up cache
       uses: ./.github/actions/rust-sccache
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,16 +107,6 @@ jobs:
         version: v0.2.15
         # change this to invalidate sccache for this job
         shared-key: v1
-    - run: |
-        which sccache
-        echo ''
-        ls /home/ec2-user/.rustup/
-        echo ''
-        ls /home/ec2-user/.rustup/toolchains/
-        echo ''
-        ls /home/ec2-user/.rustup/toolchains/nightly-2022-05-09-aarch64-unknown-linux-gnu/
-        echo ''
-        ls /home/ec2-user/.rustup/toolchains/nightly-2022-05-09-aarch64-unknown-linux-gnu/bin/
     - name: Running ${{ matrix.command }}
       uses: actions-rs/cargo@844f36862e911db73fe0815f00a4a2602c279505 # v1.0.3
       with:


### PR DESCRIPTION
###### Prerequisites - [full instructions](https://github.com/pl-strflt/tf-aws-gh-runner#how-to-use-an-existing-self-hosted-runner-type-in-your-repository)

- [x] add a full name of this repo to https://github.com/pl-strflt/tf-aws-gh-runner/blob/main/runners.tf#L21
- [x] install https://github.com/apps/pl-strflt-tf-aws-gh-runner in the org

###### Testing

- [x] CI - the remaining failures are only codecov uploads which is understandable since I don't have creds set up in this repo